### PR TITLE
Ajout de templates pour la balise Avertissement

### DIFF
--- a/xml_templates/balises/avertissement.html
+++ b/xml_templates/balises/avertissement.html
@@ -1,0 +1,12 @@
+[(#REM)
+Variables:
+  data : Contenu a parser
+-->]
+
+<B_avertissement>
+<div class="xml-avertissement lead">
+<BOUCLE_avertissement(DATA){source tableau, #ENV{data}|table_valeur{0/children}}>
+  <INCLURE{fond=xml_templates/balises/#CLE, env}{data=#VALEUR} />
+</BOUCLE_avertissement>
+</div>
+</B_avertissement>

--- a/xml_templates/balises/titre.html
+++ b/xml_templates/balises/titre.html
@@ -1,0 +1,12 @@
+[(#REM)
+Variables:
+  data : Contenu a parser
+-->]
+
+<B_titre>
+<div class="xml-titre">
+    <h3 class="panel-title" >
+        [(#ENV{data}|table_valeur{0/text})]
+    </h3>
+</div>
+</B_titre>


### PR DESCRIPTION
Il manque des templates pour la balise avertissement (il y en a une [dans ce XML](http://lecomarquage.service-public.fr/vdd/3.0/part/xml/N392.xml) par exemple).