### PR TITLE
Compatibilité avec SPIP 2.1.30

### DIFF
--- a/comarquage_fonctions.php
+++ b/comarquage_fonctions.php
@@ -49,6 +49,21 @@ function filtre_type_categorie_dist($categorie) {
 }
 
 /**
+ * Définit la variable `xml` à la valeur passée en paramètre ou à la
+ * valeur par défaut.
+ *
+ * Nécessaire pour SPIP 2, dont la balise #GET ne renvoie pas la valeur par
+ * défaut si la variable est vide.
+ *
+ * @param string $set
+ * @return string
+ */
+function filtre_set_xml($set) {
+	$xml = _request('xml');
+	return $xml ? $xml : 'accueil';
+}
+
+/**
  * Identification template
  *
  * @param string $xml
@@ -340,4 +355,31 @@ function fluxXmlObjToArr($obj, $utiliser_namespace = false, $parentName = '') {
 	}
 
 	return $tableau;
+}
+
+global $spip_version_branche;
+if($spip_version_branche[0] == "2") {
+	/**
+	 * Surcharge le filtre table_valeur pour accepter la syntaxe a/b
+	 * au lieu d'avoir à faire table_valeur{a}|table_valeur{b}.
+	 *
+	 * Nécessaire pour SPIP 2.
+	 *
+	 * @param array $table
+	 * @param string $cle
+	 * @param string $defaut
+	 * @return string
+	 */
+	function filtre_table_valeur_dist($table,$cle,$defaut='') {
+		$table = is_string($table)?unserialize($table):$table;
+		$table = is_array($table)?$table:array();
+
+		// https://stackoverflow.com/a/9628276
+		$temp = &$table;
+		foreach(explode('/', $cle) as $key) {
+			if(! isset($temp[$key])) return $defaut;
+			$temp = &$temp[$key];
+		}
+		return $temp;
+	}
 }

--- a/modeles/comarquage.html
+++ b/modeles/comarquage.html
@@ -8,7 +8,7 @@
 [(#SET{parametres,#ARRAY})]
 
 [(#SET{categorie, #ENV{categorie,'particuliers'}})]
-[(#SET{xml,#ENV{xml,#GET{xml ,'accueil'}}})]
+[(#GET{xml}|set_xml|set{xml})]
 
 #SET{parametres, #GET{parametres}|array_merge{#ARRAY{categorie,#GET{categorie}}}}
 #SET{parametres, #GET{parametres}|array_merge{#ARRAY{xml,#GET{xml}}}}

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,0 +1,16 @@
+<plugin>
+    <nom>Co-Marquage Service Public</nom>
+    <categorie>divers</categorie>
+    <auteur>Mickaël Hippocrate</auteur>
+    <auteur>Laurent Vergerolle</auteur>
+    <auteur>Olivier Watté</auteur>
+    <licence>GPL</licence>
+    <fonctions>comarquage_fonctions.php</fonctions>
+    <version>1.0.5</version>
+    <etat>stable</etat>
+    <icon>prive/themes/spip/images/picto-comarquage-service-public.png</icon>
+    <lien>http://spip-contrib.net/?article4858</lien>
+    <prefix>comarquage</prefix>
+    <necessite id="SPIP" version="[2.1.30;2.1.99]" />
+    <necessite id="iterateurs" version="[1.0.6;]" />
+</plugin>


### PR DESCRIPTION
J'ai fait de petites modifications pour que le plugin fonctionne avec SPIP 2.1.30. Il faut installer [le plugin Itérateurs](https://contrib.spip.net/Les-Iterateurs-pour-SPIP-2-1) pour que les boucles `DATA` fonctionnent.