### PR TITLE
fix: notice sur le parser_xml

### DIFF
--- a/comarquage_fonctions.php
+++ b/comarquage_fonctions.php
@@ -114,7 +114,7 @@ function type_entrer($xml) {
  * @return string
  */
 function parser_xml($xml) {
-	$id = $xml[0];
+	$id = substr($xml,0,1);
 	switch ($id) {
 		case "F":
 			$noeud = "fiche";


### PR DESCRIPTION
Nouvelle notice ce jour suite à la mise à jour : Warning: Uninitialized string offset 0 in /var/www/html/plugins/comarquage/comarquage_fonctions.php on line 117