### PR TITLE
fix bug copie_locale() et optimisation du cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Les squelettes de _Co-Marquage Service Public_ utilisent les classes et composan
 Le flux est récupéré grâce à la balise DATA. Les boucles sont en cache
 par défaut pendant **86400 secondes** (soit 24 h).
 
-Les XMLs de co-marquage sont copiés en local `|copie_locale{modif}`. Pour
+Les XMLs de co-marquage sont copiés en local `|comarquage_url_cache`. Pour
 forcer le re-téléchargement des XMLs vider le répertoire `IMG/distant/xml`.
 
 ### Astuces

--- a/comarquage_fonctions.php
+++ b/comarquage_fonctions.php
@@ -52,22 +52,22 @@ function filtre_type_categorie_dist($categorie) {
 	$parametres_xml = array();
 	switch ($categorie) {
 		case "particuliers":
-			$parametres_xml['XMLURL'] = "http://lecomarquage.service-public.fr/vdd/3.3/part/xml/";
+			$parametres_xml['XMLURL'] = "https://lecomarquage.service-public.fr/vdd/3.3/part/xml/";
 			$parametres_xml['CATEGORIE'] = "part";
 			break;
 
 		case "associations":
-			$parametres_xml['XMLURL'] = "http://lecomarquage.service-public.fr/vdd/3.3/asso/xml/";
+			$parametres_xml['XMLURL'] = "https://lecomarquage.service-public.fr/vdd/3.3/asso/xml/";
 			$parametres_xml['CATEGORIE'] = "asso";
 			break;
 
 		case 'entreprises':
-			$parametres_xml['XMLURL'] = "http://lecomarquage.service-public.fr/vdd/3.3/pro/xml/";
+			$parametres_xml['XMLURL'] = "https://lecomarquage.service-public.fr/vdd/3.3/pro/xml/";
 			$parametres_xml['CATEGORIE'] = "pro";
 			break;
 
 		default:
-			$parametres_xml['XMLURL'] = "http://lecomarquage.service-public.fr/vdd/3.3/part/xml/";
+			$parametres_xml['XMLURL'] = "https://lecomarquage.service-public.fr/vdd/3.3/part/xml/";
 			$parametres_xml['CATEGORIE'] = "part";
 			break;
 	}

--- a/comarquage_fonctions.php
+++ b/comarquage_fonctions.php
@@ -17,22 +17,70 @@ if (!defined("_ECRIRE_INC_VERSION")) {
 
 function comarquage_url_cache($url) {
 	include_spip('inc/distant');
-	if (function_exists('recuperer_url_cache')) {
+	if (function_exists('curl_init')) {
 		// version moderne
-		$fichier_cache = sous_repertoire(_DIR_CACHE, 'comarquage') . basename(nom_fichier_copie_locale($url, 'xml'));
-		$options = [
-			'delai_cache' => 3600,
-			'file' => $fichier_cache,
-		];
-		if (file_exists($fichier_cache)) {
-			$options['if_modified_since'] = filemtime($fichier_cache);
+		$fichier_copie_locale = _DIR_RACINE . nom_fichier_copie_locale($url, 'xml');
+		$fichier_cache = sous_repertoire(_DIR_CACHE, 'comarquage') . basename($fichier_copie_locale);
+		// recuperer les anciens cache de IMG/distant/ si dispo
+		if (file_exists($fichier_copie_locale) and !file_exists($fichier_cache)) {
+			@rename($fichier_copie_locale, $fichier_cache);
 		}
-		$res = recuperer_url_cache($url, $options);
-		if (!$res or !$res['length']) {
-			if (!file_exists($fichier_cache)) {
-				return false;
+
+		// le cache date de moins d'1h, on renvoie sans faire de hit sur le serveur
+		$fichier_cache_check = dirname($fichier_cache). '/.' . $fichier_cache . '.check';
+		if (file_exists($fichier_cache)) {
+			if (filemtime($fichier_cache) > $_SERVER['REQUEST_TIME'] - 3600) {
+				return $fichier_cache;
+			}
+			if (file_exists($fichier_cache_check) and filemtime($fichier_cache_check) > $_SERVER['REQUEST_TIME'] - 3600) {
+				return $fichier_cache;
 			}
 		}
+
+		// CURL le fichier car recuperer_url() tourne en boucle infinie dans certaines config depuis le 24/11/2023
+		$ch = curl_init();
+		curl_setopt($ch, CURLOPT_URL, $url);
+		curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
+
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($ch, CURLOPT_HEADER, false);
+		curl_setopt($ch, CURLOPT_ENCODING, 'gzip');
+
+		spip_log("comarquage_url_cache sur $url via curl", 'distant' . _LOG_DEBUG);
+
+		$user_agent = "SPIP/Comarquage";
+
+		$headers = [];
+		$headers[] = 'Connection: Close';
+		$headers[] = "User-Agent: $user_agent";
+
+		if (file_exists($fichier_cache)) {
+			$headers[] = "If-Modified-Since: " . gmdate('D, d M Y H:i:s \G\M\T', filemtime($fichier_cache));
+		}
+
+		curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+
+		//getting response from server
+		$response = curl_exec($ch);
+		$erreur = curl_errno($ch);
+		$erreur_msg = curl_error($ch);
+		if (!$erreur){
+			//closing the curl
+			curl_close($ch);
+			spip_log("comarquage_url_cache sur $url via curl OK : " . strlen($response).'car', 'distant');
+			if ($response) {
+				spip_log("comarquage_url_cache sur $url via curl OK : => $fichier_cache", 'distant');
+				file_put_contents($fichier_cache, $response);
+			}
+		}
+		else {
+			spip_log("comarquage_url_cache sur $url via curl HS : " . $response, 'distant' . _LOG_ERREUR);
+		}
+
+
+		// et dans tous les cas on touch le check, pour ne pas verifier de nouveau avant 1h
+		@touch($fichier_cache_check);
+
 		return $fichier_cache;
 
 	} else {

--- a/comarquage_fonctions.php
+++ b/comarquage_fonctions.php
@@ -14,6 +14,33 @@ if (!defined("_ECRIRE_INC_VERSION")) {
 	return;
 }
 
+
+function comarquage_url_cache($url) {
+	include_spip('inc/distant');
+	if (function_exists('recuperer_url_cache')) {
+		// version moderne
+		$fichier_cache = sous_repertoire(_DIR_CACHE, 'comarquage') . basename(nom_fichier_copie_locale($url, 'xml'));
+		$options = [
+			'delai_cache' => 3600,
+			'file' => $fichier_cache,
+		];
+		if (file_exists($fichier_cache)) {
+			$options['if_modified_since'] = filemtime($fichier_cache);
+		}
+		$res = recuperer_url_cache($url, $options);
+		if (!$res or !$res['length']) {
+			if (!file_exists($fichier_cache)) {
+				return false;
+			}
+		}
+		return $fichier_cache;
+
+	} else {
+		// compat old SPIP
+		return copie_locale($url, 'modif');
+	}
+}
+
 /**
  * Récupération des types de catégorie et leurs URL
  *

--- a/xml_pages/accueil.html
+++ b/xml_pages/accueil.html
@@ -10,7 +10,7 @@ Variables:
 <div class="page-accueil">
   [(#REM) Menu principal]
   <INCLURE{fond=xml_templates/menu, env}{base_url=#ENV{url}} />
-<BOUCLE_accueil(DATA){source simplexml, #GET{url}|copie_locale{modif}}
+<BOUCLE_accueil(DATA){source simplexml, (#GET{url}|comarquage_url_cache)}
   {datapath root/children}{datacache #GET{datacache}}>
   <INCLURE{fond=xml_templates/balises/#CLE|replace{:,/}, env}{data=#VALEUR} />
 </BOUCLE_accueil>

--- a/xml_pages/centresdecontact.html
+++ b/xml_pages/centresdecontact.html
@@ -8,7 +8,7 @@ Variables:
 
 <B_centresdecontact>
 <div class="page-centresdecontact">
-<BOUCLE_centresdecontact(DATA){source simplexml, #GET{url}|copie_locale{modif}, namespace}
+<BOUCLE_centresdecontact(DATA){source simplexml, (#GET{url}|comarquage_url_cache), namespace}
   {datapath root/children}{datacache #GET{datacache}}>
   <INCLURE{fond=xml_templates/balises/#CLE|replace{:,/}, env}{data=#VALEUR} />
 </BOUCLE_centresdecontact>

--- a/xml_pages/commentfairesi.html
+++ b/xml_pages/commentfairesi.html
@@ -8,7 +8,7 @@ Variables:
 
 <B_commentfairesi>
 <div class="page-commentfairesi">
-<BOUCLE_commentfairesi(DATA){source simplexml, #GET{url}|copie_locale{modif}, namespace}
+<BOUCLE_commentfairesi(DATA){source simplexml, (#GET{url}|comarquage_url_cache), namespace}
   {datapath root/children}{datacache #GET{datacache}}>
   <INCLURE{fond=xml_templates/balises/#CLE|replace{:,/}, env}{data=#VALEUR} />
 </BOUCLE_commentfairesi>

--- a/xml_pages/fiche.html
+++ b/xml_pages/fiche.html
@@ -8,7 +8,7 @@ Variables:
 
 <B_fiche>
 <div class="page-fiche">
-<BOUCLE_fiche(DATA){source comarquagexml, #GET{url}|copie_locale{modif}, namespace}
+<BOUCLE_fiche(DATA){source comarquagexml, (#GET{url}|comarquage_url_cache), namespace}
   {datapath root/children}{datacache #GET{datacache}}>
   <INCLURE{fond=xml_templates/balises/#CLE|replace{:,/}, env}{data=#VALEUR} />
 </BOUCLE_fiche>

--- a/xml_pages/noeud.html
+++ b/xml_pages/noeud.html
@@ -8,7 +8,7 @@ Variables:
 
 <B_noeud>
 <div class="page-noeud">
-<BOUCLE_noeud(DATA){source comarquagexml, #GET{url}|copie_locale{modif}, namespace}
+<BOUCLE_noeud(DATA){source comarquagexml, (#GET{url}|comarquage_url_cache), namespace}
   {datapath root/children}{datacache #GET{datacache}}>
   <INCLURE{fond=xml_templates/balises/#CLE|replace{:,/}, env}{data=#VALEUR} />
 </BOUCLE_noeud>

--- a/xml_pages/questionsreponses.html
+++ b/xml_pages/questionsreponses.html
@@ -8,7 +8,7 @@ Variables:
 
 <B_questionsreponses>
 <div class="page-questionsreponses">
-<BOUCLE_questionsreponses(DATA){source simplexml, #GET{url}|copie_locale{modif}, namespace}
+<BOUCLE_questionsreponses(DATA){source simplexml, (#GET{url}|comarquage_url_cache), namespace}
   {datapath root/children}{datacache #GET{datacache}}>
   <INCLURE{fond=xml_templates/balises/#CLE|replace{:,/}, env}{data=#VALEUR} />
 </BOUCLE_questionsreponses>

--- a/xml_pages/ressource.html
+++ b/xml_pages/ressource.html
@@ -8,7 +8,7 @@ Variables:
 
 <B_ressource>
 <div class="page-ressource">
-<BOUCLE_ressource(DATA){source comarquagexml, #GET{url}|copie_locale{modif}, namespace}
+<BOUCLE_ressource(DATA){source comarquagexml, (#GET{url}|comarquage_url_cache), namespace}
   {datapath root/children}{datacache #GET{datacache}}>
   <INCLURE{fond=xml_templates/balises/#CLE|replace{:,/}, env}{data=#VALEUR} />
 </BOUCLE_ressource>

--- a/xml_pages/servicesenligne.html
+++ b/xml_pages/servicesenligne.html
@@ -8,7 +8,7 @@ Variables:
 
 <B_servicesenligne>
 <div class="page-servicesenligne">
-<BOUCLE_servicesenligne(DATA){source simplexml, #GET{url}|copie_locale{modif}, namespace}
+<BOUCLE_servicesenligne(DATA){source simplexml, (#GET{url}|comarquage_url_cache), namespace}
   {datapath root/children}{datacache #GET{datacache}}>
   <INCLURE{fond=xml_templates/balises/#CLE|replace{:,/}, env}{data=#VALEUR} />
 </BOUCLE_servicesenligne>

--- a/xml_templates/menu.html
+++ b/xml_templates/menu.html
@@ -9,7 +9,7 @@ Variables:
 
 <B_menu>
 <div class="xml-menu">
-<BOUCLE_menu(DATA){source simplexml,#GET{url}|copie_locale{modif}}
+<BOUCLE_menu(DATA){source simplexml,(#GET{url}|comarquage_url_cache)}
   {datapath root/children}{datacache #GET{datacache}}>
   <INCLURE{fond=xml_templates/menu/#CLE, env}{data=#VALEUR} />
 </BOUCLE_menu>


### PR DESCRIPTION
Depuis le 24/11/2023 le serveur comarquage réponds de manière innatendue et provoque une boucle infinie dans la fonction `recuperer_body()` https://git.spip.net/spip/spip/src/branch/3.2/ecrire/inc/distant.php#L847 où la condition `feof()` n'est jamais remplie (connection fermée automatiquement par le serveur ?)

Un patch SPIP sera envoyé dans les versions maintenues, mais ne sera pas dispo dans les versions 3.x de SPIP.
On remplace donc le filtre `|copie_locale` par un filtre `|comarquage_url_cache` qui utilise curl et une gestion améliorée des requêtes pour ne jamais requêter une même URL plus d'une fois par heure 

+ passer les URLs en https pour eviter une redirection